### PR TITLE
fix: retrieve offers_V2 fields for exclusive Prime offers

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -1,5 +1,10 @@
 FROM python:3.11-slim AS base
 
+# 1) Install git (and clean up apt cache)
+RUN apt-get update \
+&& apt-get install -y --no-install-recommends git \
+&& rm -rf /var/lib/apt/lists/*
+
 # Create a non-root user and group
 RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
 

--- a/app/repositories/product.py
+++ b/app/repositories/product.py
@@ -1,4 +1,13 @@
-from amazon_paapi import AmazonApi
+#from amazon_paapi import AmazonApi
+import re
+from typing import Optional
+import paapi5_python_sdk
+from paapi5_python_sdk.api.default_api import DefaultApi
+from paapi5_python_sdk.partner_type import PartnerType
+from paapi5_python_sdk.get_items_request import GetItemsRequest
+from paapi5_python_sdk.get_items_resource import GetItemsResource
+from paapi5_python_sdk.rest import ApiException
+
 from app.config import settings
 from app.schemas.product import Product
 
@@ -21,37 +30,88 @@ class ProductNotFound(ProductRepositoryError):
 
 class ProductRepository:
     setting: settings.Settings
-    amazon: AmazonApi
 
     def __init__(self, setting: settings.Settings):
-        self.setting = setting
-
-        self.amazon = AmazonApi(
-            self.setting.AMAZON_ACCESS_KEY,
-            self.setting.AMAZON_SECRET_KEY,
-            self.setting.AMAZON_PARTNER_TAG,
-            self.setting.AMAZON_COUNTRY,  # pyright:ignore
+    # 1) configure the PA-API client
+        cfg = paapi5_python_sdk.Configuration(
+            access_key=setting.AMAZON_ACCESS_KEY,
+            secret_key=setting.AMAZON_SECRET_KEY,
+            host="webservices.amazon.com.br",        # or your regional endpoint
+            region=setting.AMAZON_COUNTRY,       # e.g. "us-east-1"
         )
+        
+        self.setting = setting
+        self.client = DefaultApi(paapi5_python_sdk.ApiClient(cfg))
+        self.partner_tag = setting.AMAZON_PARTNER_TAG
+        self.marketplace = setting.AMAZON_COUNTRY
+    
+    @staticmethod
+    def _extract_asin(url: str) -> str:
+        """Pull the 10-char ASIN out of an Amazon URL."""
+        m = re.search(r"/([A-Z0-9]{10})(?:[/?]|$)", url)
+        if not m:
+            raise ProductRepositoryError(f"Could not extract ASIN from URL: {url}")
+        return m.group(1)
 
     def get_product_by_url(self, url: str) -> Product:
         try:
-            item = self.amazon.get_items(url)[0]
+            asin = self._extract_asin(url)
 
+            # 2) build our GetItemsRequest, including the OffersV2 fields
+            request = GetItemsRequest(
+                partner_tag=self.partner_tag,
+                partner_type=PartnerType.ASSOCIATES,
+                marketplace=self.marketplace,
+                item_ids=[asin],
+                resources=[
+                    # core info
+                    GetItemsResource.IMAGES_PRIMARY_LARGE,
+                    GetItemsResource.ITEM_INFO_TITLE,
+                    GetItemsResource.DETAIL_PAGE_URL,
+                    # legacy Offers (fallback)
+                    GetItemsResource.OFFERS_LISTINGS_PRICE,
+                    # new OffersV2
+                    GetItemsResource.OFFERSV2_LISTINGS_PRICE,
+                    GetItemsResource.OFFERSV2_LISTINGS_DEALDETAILS,
+                    GetItemsResource.OFFERSV2_LISTINGS_SAVINGS,
+                ],
+            )
+
+            # 3) hit the API
+            response = self.client.get_items(request)
+            if not response.items_result or not response.items_result.items:
+                raise ProductNotFound(url)
+
+            item = response.items_result.items[0]
+
+            # 4) extract common fields
             image = item.images.primary.large.url
             title = item.item_info.title.display_value
-            url = item.detail_page_url
+            detail_url = item.detail_page_url
 
-            if item.offers.listings == None:
-                raise ProductRepositoryError(f"This product doesn't have a listing")
+            # 5) find the prime-exclusive price if present
+            prime_price: Optional[str] = None
+            for listing in (item.offers_v2 or []).listings or []:
+                if listing.deal_details and listing.deal_details.access_type == "PRIME_EXCLUSIVE":
+                    prime_price = listing.price.money.display_amount
+                    break
 
-            price = item.offers.listings[0].price.display_amount
+            # 6) fallback to the first (regular) offer if no Prime-only deal
+            if prime_price is None:
+                if item.offers and item.offers.listings:
+                    prime_price = item.offers.listings[0].price.display_amount
+                else:
+                    raise ProductRepositoryError("No offer price available for this product")
 
-            saving = None
-            if (item.offers.listings[0].price.savings) != None: 
-                saving = item.offers.listings[0].price.savings.display_amount
+            return Product(
+                image=image,
+                title=title,
+                url=detail_url,
+                price=prime_price,
+                saving=None,  # you can add savings extraction similarly if you need it
+            )
 
-            return Product(image=image, title=title, url=url, price=price, saving=saving)
+        except ApiException as e:
+            raise ProductRepositoryError(f"PA-API error: {e.status} {e.body}")
         except Exception as e:
-            raise ProductRepositoryError(f"An unexpected error occurred: {str(e)}")
-
-
+            raise ProductRepositoryError(str(e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,6 @@ bleach
 cloudinary
 redis
 celery[redis]
+git+https://github.com/hirotoshi/paapi5-python-sdk.git#egg=paapi5_python_sdk
 python-amazon-paapi
 openai


### PR DESCRIPTION
@henrybarreto  Our current repository **product** is unable to retrieve special offers for Prime members, which appears to be a critical issue for Amazon Prime Day. These parameters are found as `OffersV2.Listings.DealDetails` and `OffersV2.Listings.Price` in the Amazon ScratchPad.

I tried to sort this limitation out by calling the offers V2 fields via the current library amazon_paapi, which was unsuccessful. It appears that this current library does not support the data we require. To overcome that, I also tried to use the official library, but got stuck with the Docker image build at the requirements.txt step, line 18. Therefore, I couldn’t go any further with the refactoring of [product.py](http://product.py/).